### PR TITLE
Add rlib to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 [dependencies]
 curv = { git = "https://github.com/KZen-networks/curv" , features =  ["ec_ed25519"]}


### PR DESCRIPTION
I was unable to use the library along side `Tokio` on the latest rust-nightly version.

When importing both the following error occurs: 
```
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/home/amanusk/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib"...
```
This change to Cargo.toml seems to fix this issue

