### PR TITLE
fix: KeyGen panics in probability n/256

### DIFF
--- a/src/protocols/aggsig/mod.rs
+++ b/src/protocols/aggsig/mod.rs
@@ -50,40 +50,25 @@ pub struct KeyPair {
 
 impl KeyPair {
     pub fn create() -> KeyPair {
-        let ec_point: GE = ECPoint::generator();
         let sk: FE = ECScalar::new_random();
-        let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
-        let h_vec = BigInt::to_vec(&h);
-        let mut private_key: [u8; 32] = [0u8; 32];
-        let mut prefix: [u8; 32] = [0u8; 32];
-        prefix.copy_from_slice(&h_vec[32..64]);
-        private_key.copy_from_slice(&h_vec[00..32]);
-        private_key[0] &= 248;
-        private_key[31] &= 63;
-        private_key[31] |= 64;
-        let private_key = &private_key[..private_key.len()];
-        let prefix = &prefix[..prefix.len()];
-        let private_key: FE = ECScalar::from(&BigInt::from(private_key));
-        let prefix: FE = ECScalar::from(&BigInt::from(prefix));
-        let public_key = ec_point * &private_key;
-        KeyPair {
-            public_key,
-            expended_private_key: ExpendedPrivateKey {
-                prefix,
-                private_key,
-            },
-        }
+        Self::create_from_private_key_internal(&sk)
     }
 
     pub fn create_from_private_key(secret: &BigInt) -> KeyPair {
         let sk: FE = ECScalar::from(secret);
+        Self::create_from_private_key_internal(&sk)
+    }
+
+    fn create_from_private_key_internal(sk: &FE) -> KeyPair {
         let ec_point: GE = ECPoint::generator();
         let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
         let h_vec = BigInt::to_vec(&h);
+        let mut h_vec_padded = vec![0; 64 - h_vec.len()];  // ensure hash result is padded to 64 bytes
+        h_vec_padded.extend_from_slice(&h_vec);
         let mut private_key: [u8; 32] = [0u8; 32];
         let mut prefix: [u8; 32] = [0u8; 32];
-        prefix.copy_from_slice(&h_vec[32..64]);
-        private_key.copy_from_slice(&h_vec[00..32]);
+        prefix.copy_from_slice(&h_vec_padded[32..64]);
+        private_key.copy_from_slice(&h_vec_padded[00..32]);
         private_key[0] &= 248;
         private_key[31] &= 63;
         private_key[31] |= 64;

--- a/src/protocols/aggsig/test.rs
+++ b/src/protocols/aggsig/test.rs
@@ -30,6 +30,12 @@ mod tests {
 
     #[test]
     fn test_multiparty_signing_for_two_parties() {
+        for _i in 0..256 {
+            test_multiparty_signing_for_two_parties_internal();
+        }
+    }
+
+    fn test_multiparty_signing_for_two_parties_internal() {
         let message: [u8; 4] = [79, 77, 69, 82];
 
         // round 0: generate signing keys
@@ -97,6 +103,12 @@ mod tests {
 
     #[test]
     fn test_multiparty_signing_for_three_parties() {
+        for _i in 0..256 {
+            test_multiparty_signing_for_three_parties_internal();
+        }
+    }
+
+    fn test_multiparty_signing_for_three_parties_internal() {
         let message: [u8; 4] = [79, 77, 69, 82];
 
         // round 0: generate signing keys

--- a/src/protocols/multisig/test.rs
+++ b/src/protocols/multisig/test.rs
@@ -26,6 +26,12 @@ mod tests {
 
     #[test]
     fn two_party_key_gen() {
+        for _i in 0..256 {
+            two_party_key_gen_internal();
+        }
+    }
+
+    fn two_party_key_gen_internal() {
         let message_vec = vec![79, 77, 69, 82];
         let message_bn = BigInt::from(&message_vec[..]);
         let message = HSha256::create_hash(&vec![&message_bn]);

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -75,40 +75,25 @@ pub struct Signature {
 
 impl Keys {
     pub fn phase1_create(index: usize) -> Keys {
-        let ec_point: GE = ECPoint::generator();
         let sk: FE = ECScalar::new_random();
-        let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
-        let h_vec = BigInt::to_vec(&h);
-        let mut private_key: [u8; 32] = [0u8; 32];
-        let mut prefix: [u8; 32] = [0u8; 32];
-        prefix.copy_from_slice(&h_vec[32..64]);
-        private_key.copy_from_slice(&h_vec[00..32]);
-        private_key[0] &= 248;
-        private_key[31] &= 63;
-        private_key[31] |= 64;
-        let private_key = &private_key[..private_key.len()];
-        let prefix = &prefix[..prefix.len()];
-        let private_key: FE = ECScalar::from(&BigInt::from(private_key));
-        let prefix: FE = ECScalar::from(&BigInt::from(prefix));
-        let public_key = ec_point * &private_key;
-
-        Keys {
-            u_i: private_key,
-            y_i: public_key,
-            prefix,
-            party_index: index.clone(),
-        }
+        Self::phase1_create_from_private_key_internal(index, &sk)
     }
 
     pub fn phase1_create_from_private_key(index: usize, secret: &BigInt) -> Keys {
         let sk: FE = ECScalar::from(secret);
+        Self::phase1_create_from_private_key_internal(index, &sk)
+    }
+
+    fn phase1_create_from_private_key_internal(index: usize, sk: &FE) -> Keys {
         let ec_point: GE = ECPoint::generator();
         let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
         let h_vec = BigInt::to_vec(&h);
+        let mut h_vec_padded = vec![0; 64 - h_vec.len()];  // ensure hash result is padded to 64 bytes
+        h_vec_padded.extend_from_slice(&h_vec);
         let mut private_key: [u8; 32] = [0u8; 32];
         let mut prefix: [u8; 32] = [0u8; 32];
-        prefix.copy_from_slice(&h_vec[32..64]);
-        private_key.copy_from_slice(&h_vec[00..32]);
+        prefix.copy_from_slice(&h_vec_padded[32..64]);
+        private_key.copy_from_slice(&h_vec_padded[00..32]);
         private_key[0] &= 248;
         private_key[31] &= 63;
         private_key[31] |= 64;

--- a/src/protocols/thresholdsig/test.rs
+++ b/src/protocols/thresholdsig/test.rs
@@ -17,9 +17,14 @@ mod tests {
     use protocols::thresholdsig::*;
 
     #[test]
-    #[allow(unused_doc_comments)]
     fn test_t2_n4() {
-        /// this test assumes that in keygen we have n=4 parties and in signing we have 4 parties as well.
+        for _i in 0..256 {
+            test_t2_n4_internal();
+        }
+    }
+
+    fn test_t2_n4_internal() {
+        // this test assumes that in keygen we have n=4 parties and in signing we have 4 parties as well.
         let t = 2;
         let n = 4;
         let key_gen_parties_index_vec: [usize; 4] = [0, 1, 2, 3];
@@ -61,8 +66,14 @@ mod tests {
     }
 
     #[test]
-    #[allow(unused_doc_comments)]
     fn test_t2_n5_sign_with_4() {
+        for _i in 0..256 {
+            test_t2_n5_sign_with_4_internal();
+        }
+    }
+
+    #[allow(unused_doc_comments)]
+    fn test_t2_n5_sign_with_4_internal() {
         /// this test assumes that in keygen we have n=4 parties and in signing we have 4 parties, indices 0,1,3,4.
         let t = 2;
         let n = 5;


### PR DESCRIPTION
Generating a local key (share) panics whenever the leading byte is all 0s, e.g.:
```
thread 'protocols::multisig::test::tests::two_party_key_gen' panicked at 'index 64 out of range for slice of length 63', src/libcore/slice/mod.rs:2583:5
```

This happens in probability 1/256.
So the entire distributed KeyGen process fails whenever one of the parties panics, hence the probability is (num of parties)/256. 

Reason:
`HSha512::create_hash` is expected to return a 64 bytes hash, although this is a vector of variable length: it does not including leading bytes which are all 0s.

This issue is relevant and handled for all 3 types of signatures schemes: threshold, aggregated, multi.
