### PR TITLE
curv@v0.2.0-ed25519

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-curv = { git = "https://github.com/KZen-networks/curv" , features =  ["ec_ed25519"]}
+curv = { git = "https://github.com/KZen-networks/curv", tag = "v0.2.0-ed25519", features =  ["ec_ed25519"]}
 hex = "0.3.2"
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
use curv package with tag `v0.2.0-ed25519`:

- tag is of same commit as tag `v0.2.0`, but with this tag, when `multi-party-eddsa` is consumed as a dependency along with other dependencies which consume curv with tag `v0.2.0` - the compilation goes through (even when conflicting curv features are used).
- allows to delete https://github.com/KZen-networks/curv-replica